### PR TITLE
Flexible preconditioning solvers

### DIFF
--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -81,8 +81,8 @@ class Rexi(object):
         ar0 = []
         ai0 = []
         for l in range(len(alpha_is)):
-            ar0.append(Constant(alpha[alpha_is].real))
-            ari.append(Constant(alpha[nalpha-1].real))
+            ar0.append(Constant(alpha[alpha_is[l]].real))
+            ari.append(Constant(alpha[nalpha_is[l]].real))
             
         # indices to select which solvers to use for each coefficient
         self.solver_list = [0]*nalpha/2 + [1]*(nalpha-nalpha/2)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -121,10 +121,11 @@ class Rexi(object):
             )
 
             # (1,1) block
-            aP = (ar0[i] - abs(ai0[i]))*inner_m(u1r, h1r, wr, phr)
+            si = self.solver_list[i]
+            aP = (ar0[si] - abs(ai0[si]))*inner_m(u1r, h1r, wr, phr)
             aP += L_op(u1r, h1r, wr, phr)
             # (2,2) block
-            aP += (ar0[i] - abs(ai0[i]))*inner_m(u1i, h1i, wi, phi)
+            aP += (ar0[si] - abs(ai0[si]))*inner_m(u1i, h1i, wi, phi)
             aP += L_op(u1i, h1i, wi, phi)
             
             myprob = LinearVariationalProblem(a, L, self.w, aP=aP,

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -48,6 +48,8 @@ class Rexi(object):
                                  "fieldsplit_1_pc_type": "lu"}
 
 
+            
+
         self.w_sum = Function(W)
         self.w = Function(W)
         for i in range(len(alpha)):

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -82,7 +82,7 @@ class Rexi(object):
         ai0 = []
         for l in range(len(alpha_is)):
             ar0.append(Constant(alpha[alpha_is[l]].real))
-            ari.append(Constant(alpha[nalpha_is[l]].real))
+            ai0.append(Constant(alpha[alpha_is[l]].real))
             
         # indices to select which solvers to use for each coefficient
         self.solver_list = [0]*nalpha/2 + [1]*(nalpha-nalpha/2)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -57,7 +57,7 @@ class Rexi(object):
                                  "fieldsplit_0": hybridisation_parameters,
                                  "fieldsplit_1": hybridisation_parameters}
             # For reusing solver with different A, but same aP.
-            # solver_parameters["ksp_reuse_preconditioner"] = True
+            solver_parameters["ksp_reuse_preconditioner"] = True
 
         self.w_sum = Function(W)
         self.w = Function(W)
@@ -111,7 +111,8 @@ class Rexi(object):
             aP += (ar - abs(ai))*inner_m(u1i, h1i, wi, phi)
             aP += L_op(u1i, h1i, wi, phi)
             
-            myprob = LinearVariationalProblem(a, L, self.w, aP=aP)
+            myprob = LinearVariationalProblem(a, L, self.w, aP=aP,
+                                              constant_jacobian=False)
 
             self.rexi_solver.append(LinearVariationalSolver(
                 myprob, solver_parameters=solver_parameters))

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -85,7 +85,7 @@ class Rexi(object):
             ai0.append(Constant(alpha[alpha_is[l]].real))
             
         # indices to select which solvers to use for each coefficient
-        self.solver_list = [0]*nalpha/2 + [1]*(nalpha-nalpha/2)
+        self.solver_list = [0]*(nalpha//2) + [1]*(nalpha-nalpha//2)
 
         self.ai = Constant(alpha[0].imag)
         self.bi = Constant(beta_re[0].imag)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -41,11 +41,7 @@ class Rexi(object):
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
                                         'hybridization': {'ksp_type': 'preonly',
-                                                          'pc_type': 'lu',
-                                                          'hdiv_residual_ksp_type': 'preonly',
-                                                          'hdiv_residual_pc_type': 'lu', 
-                                                          'hdiv_projection_ksp_type': 'preonly',
-                                                          'hdiv_projection_pc_type': 'lu'}}
+                                                          'pc_type': 'lu'}}
 
             lu_parameters = {'ksp_type':'preonly',
                              'pc_type':'lu'}

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -92,7 +92,7 @@ class Rexi(object):
         self.ar = Constant(alpha[0].real)
         self.br = Constant(beta_re[0].real)
         
-        for i in range(len(self.solver_list)):
+        for i in range(len(alpha_is)):
 
             # (1           -sgn(ai))*(ar + L    -ai   )
             # (sgn(ai)            1) (ai        ar + L)
@@ -121,11 +121,10 @@ class Rexi(object):
             )
 
             # (1,1) block
-            si = self.solver_list[i]
-            aP = (ar0[si] - abs(ai0[si]))*inner_m(u1r, h1r, wr, phr)
+            aP = (ar0[i] - abs(ai0[i]))*inner_m(u1r, h1r, wr, phr)
             aP += L_op(u1r, h1r, wr, phr)
             # (2,2) block
-            aP += (ar0[si] - abs(ai0[si]))*inner_m(u1i, h1i, wi, phi)
+            aP += (ar0[i] - abs(ai0[i]))*inner_m(u1i, h1i, wi, phi)
             aP += L_op(u1i, h1i, wi, phi)
             
             myprob = LinearVariationalProblem(a, L, self.w, aP=aP,

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -76,7 +76,7 @@ class Rexi(object):
         
         # This is where we set how many solvers we'd like and which
         # values to use: would be nice to handle this through the options.
-        alpha_is = [nalpha//4,3*nalpha//4]
+        alpha_is = [nalpha//3, 2*(nalpha//3), nalpha-1]
         ar0 = []
         ai0 = []
         for l in range(len(alpha_is)):
@@ -84,8 +84,9 @@ class Rexi(object):
             ai0.append(Constant(alpha[alpha_is[l]].imag))
             
         # indices to select which solvers to use for each coefficient
-        self.solver_list = [0]*(nalpha//2) + [1]*(nalpha-nalpha//2)
-
+        self.solver_list = [0]*(nalpha//3) + [1]*(nalpha//3) + [2]*(nalpha-2*(nalpha//3))
+        assert(len(self.solver_list) == len(alpha))
+        
         self.ai = Constant(alpha[0].imag)
         self.bi = Constant(beta_re[0].imag)
         self.ar = Constant(alpha[0].real)
@@ -139,7 +140,7 @@ class Rexi(object):
 
         self.w_sum.assign(0.)
 
-        for i in range(len(self.solver_list)):
+        for i in range(len(self.alpha)):
             self.ar.assign(self.alpha[i].real)
             self.ai.assign(self.alpha[i].imag)
             self.br.assign(self.beta_re[i].real)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -61,7 +61,7 @@ class Rexi(object):
                                  "fieldsplit_0": hybridisation_parameters,
                                  "fieldsplit_1": hybridisation_parameters}
             # For reusing solver with different A, but same aP.
-            #solver_parameters["ksp_reuse_preconditioner"] = True
+            solver_parameters["ksp_reuse_preconditioner"] = True
 
         self.w_sum = Function(W)
         self.w = Function(W)
@@ -82,7 +82,7 @@ class Rexi(object):
         ai0 = []
         for l in range(len(alpha_is)):
             ar0.append(Constant(alpha[alpha_is[l]].real))
-            ai0.append(Constant(alpha[alpha_is[l]].real))
+            ai0.append(Constant(alpha[alpha_is[l]].imag))
             
         # indices to select which solvers to use for each coefficient
         self.solver_list = [0]*(nalpha//2) + [1]*(nalpha-nalpha//2)
@@ -140,7 +140,7 @@ class Rexi(object):
 
         self.w_sum.assign(0.)
 
-        for i in range(len(self.rexi_solver)):
+        for i in range(len(self.solver_list)):
             self.ar.assign(self.alpha[i].real)
             self.ai.assign(self.alpha[i].imag)
             self.br.assign(self.beta_re[i].real)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -53,13 +53,14 @@ class Rexi(object):
                                  "pc_type": "fieldsplit",
                                  "mat_type": "aij",
                                  "pc_fieldsplit_type": "multiplicative",
+                                 "pc_fieldsplit_off_diag_use_amat": True,
                                  "pc_fieldsplit_0_fields": "0,1",
                                  "pc_fieldsplit_1_fields": "2,3",
                                  "fieldsplit_0_ksp_type": "preonly",
                                  "fieldsplit_1_ksp_type": "preonly",
                                  "fieldsplit_0_pc_type": "lu",
                                  "fieldsplit_1_pc_type": "lu"}
-            
+
 
         self.w_sum = Function(W)
         self.w = Function(W)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -36,15 +36,20 @@ class Rexi(object):
                                  'pc_type':'lu',
                                  'pc_factor_mat_solver_package': 'mumps'}
         else:
-                        
+            lu_parameters = {'ksp_type':'preonly',
+                             'pc_type':'lu'}
+
+            gamg_parameters = {'ksp_type':'richardson',
+                               'pc_type':'gamg',
+                               'mg_levels_pc_type':'bjacobi',
+                               'mg_levels_sub_pc_type':'sor',
+                               'ksp_max_it':4,
+                               'ksp_reuse_preconditioner':True}
+
             hybridisation_parameters = {'ksp_type': 'preonly',
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
-                                        'hybridization': {'ksp_type': 'preonly',
-                                                          'pc_type': 'lu'}}
-
-            lu_parameters = {'ksp_type':'preonly',
-                             'pc_type':'lu'}
+                                        'hybridization': lu_parameters}
             
             solver_parameters = {"ksp_type": "gmres",
                                  'mat_type': 'matfree',

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -92,7 +92,7 @@ class Rexi(object):
         self.ar = Constant(alpha[0].real)
         self.br = Constant(beta_re[0].real)
         
-        for i in range(len(solver_list)):
+        for i in range(len(self.solver_list)):
 
             # (1           -sgn(ai))*(ar + L    -ai   )
             # (sgn(ai)            1) (ai        ar + L)
@@ -124,7 +124,7 @@ class Rexi(object):
             aP = (ar0[i] - abs(ai0[i]))*inner_m(u1r, h1r, wr, phr)
             aP += L_op(u1r, h1r, wr, phr)
             # (2,2) block
-            aP += (ar0[i] - abs(ai0)[i])*inner_m(u1i, h1i, wi, phi)
+            aP += (ar0[i] - abs(ai0[i]))*inner_m(u1i, h1i, wi, phi)
             aP += L_op(u1i, h1i, wi, phi)
             
             myprob = LinearVariationalProblem(a, L, self.w, aP=aP,

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -35,9 +35,8 @@ class Rexi(object):
                                  'pc_type':'lu',
                                  'pc_factor_mat_solver_package': 'mumps'}
         else:
-            
+                        
             hybridisation_parameters = {'ksp_type': 'preonly',
-                                        'mat_type': 'matfree',
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
                                         'hybridization': {'ksp_type': 'preonly',
@@ -47,20 +46,18 @@ class Rexi(object):
                                                           'hdiv_residual_pc_type': 'sor', 
                                                           'hdiv_projection_ksp_type': 'preonly',
                                                           'hdiv_projection_pc_type': 'sor'}}
-            
             solver_parameters = {"ksp_type": "gmres",
+                                 'mat_type': 'matfree',
                                  "ksp_converged_reason": True,
                                  "pc_type": "fieldsplit",
-                                 "mat_type": "aij",
                                  "pc_fieldsplit_type": "multiplicative",
                                  "pc_fieldsplit_off_diag_use_amat": True,
                                  "pc_fieldsplit_0_fields": "0,1",
                                  "pc_fieldsplit_1_fields": "2,3",
-                                 "fieldsplit_0_ksp_type": "preonly",
-                                 "fieldsplit_1_ksp_type": "preonly",
-                                 "fieldsplit_0_pc_type": "lu",
-                                 "fieldsplit_1_pc_type": "lu"}
-
+                                 "fieldsplit_0": hybridisation_parameters,
+                                 "fieldsplit_1": hybridisation_parameters}
+            # For reusing solver with different A, but same aP.
+            # solver_parameters["ksp_reuse_preconditioner"] = True
 
         self.w_sum = Function(W)
         self.w = Function(W)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -40,12 +40,11 @@ class Rexi(object):
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
                                         'hybridization': {'ksp_type': 'preonly',
-                                                          'ksp_monitor': True,
-                                                          'pc_type': 'hypre',
+                                                          'pc_type': 'lu',
                                                           'hdiv_residual_ksp_type': 'preonly',
-                                                          'hdiv_residual_pc_type': 'sor', 
+                                                          'hdiv_residual_pc_type': 'lu', 
                                                           'hdiv_projection_ksp_type': 'preonly',
-                                                          'hdiv_projection_pc_type': 'sor'}}
+                                                          'hdiv_projection_pc_type': 'lu'}}
             solver_parameters = {"ksp_type": "gmres",
                                  'mat_type': 'matfree',
                                  "ksp_converged_reason": True,
@@ -57,7 +56,7 @@ class Rexi(object):
                                  "fieldsplit_0": hybridisation_parameters,
                                  "fieldsplit_1": hybridisation_parameters}
             # For reusing solver with different A, but same aP.
-            solver_parameters["ksp_reuse_preconditioner"] = True
+            #solver_parameters["ksp_reuse_preconditioner"] = True
 
         self.w_sum = Function(W)
         self.w = Function(W)
@@ -111,8 +110,7 @@ class Rexi(object):
             aP += (ar - abs(ai))*inner_m(u1i, h1i, wi, phi)
             aP += L_op(u1i, h1i, wi, phi)
             
-            myprob = LinearVariationalProblem(a, L, self.w, aP=aP,
-                                              constant_jacobian=False)
+            myprob = LinearVariationalProblem(a, L, self.w, aP=aP)
 
             self.rexi_solver.append(LinearVariationalSolver(
                 myprob, solver_parameters=solver_parameters))

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -40,11 +40,11 @@ class Rexi(object):
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
                                         'hybridization': {'ksp_type': 'preonly',
-                                                          'pc_type': 'lu',
+                                                          'pc_type': 'ilu',
                                                           'hdiv_residual_ksp_type': 'preonly',
-                                                          'hdiv_residual_pc_type': 'lu', 
+                                                          'hdiv_residual_pc_type': 'ilu', 
                                                           'hdiv_projection_ksp_type': 'preonly',
-                                                          'hdiv_projection_pc_type': 'lu'}}
+                                                          'hdiv_projection_pc_type': 'ilu'}}
             solver_parameters = {"ksp_type": "gmres",
                                  'mat_type': 'matfree',
                                  "ksp_converged_reason": True,

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -40,11 +40,15 @@ class Rexi(object):
                                         'pc_type': 'python',
                                         'pc_python_type': 'firedrake.HybridizationPC',
                                         'hybridization': {'ksp_type': 'preonly',
-                                                          'pc_type': 'ilu',
+                                                          'pc_type': 'lu',
                                                           'hdiv_residual_ksp_type': 'preonly',
-                                                          'hdiv_residual_pc_type': 'ilu', 
+                                                          'hdiv_residual_pc_type': 'lu', 
                                                           'hdiv_projection_ksp_type': 'preonly',
-                                                          'hdiv_projection_pc_type': 'ilu'}}
+                                                          'hdiv_projection_pc_type': 'lu'}}
+
+            lu_parameters = {'ksp_type':'preonly',
+                             'pc_type':'lu'}
+            
             solver_parameters = {"ksp_type": "gmres",
                                  'mat_type': 'matfree',
                                  "ksp_converged_reason": True,
@@ -70,7 +74,9 @@ class Rexi(object):
         def inner_m(u, h, v, q):
             return inner(u,v)*dx + h*q*dx
 
-
+        ar0 = Constant(alpha[0].real)
+        ai0 = Constant(alpha[0].imag)
+        
         for i in range(len(alpha)):
             ai = Constant(alpha[i].imag)
             bi = Constant(beta_re[i].imag)

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -77,7 +77,10 @@ class Rexi(object):
 
         nalpha = len(alpha)
         # indices to make solvers with
-        alpha_is = [0,nalpha-1]
+        
+        # This is where we set how many solvers we'd like and which
+        # values to use: would be nice to handle this through the options.
+        alpha_is = [nalpha//4,3*nalpha//4]
         ar0 = []
         ai0 = []
         for l in range(len(alpha_is)):

--- a/frexi_sphere/rexi.py
+++ b/frexi_sphere/rexi.py
@@ -142,10 +142,10 @@ class Rexi(object):
         self.w_sum.assign(0.)
 
         for i in range(len(self.rexi_solver)):
-            self.ar.assign(alpha[i].real)
-            self.ai.assign(alpha[i].imag)
-            self.br.assign(beta_re[i].real)
-            self.bi.assign(beta_re[i].imag)
+            self.ar.assign(self.alpha[i].real)
+            self.ai.assign(self.alpha[i].imag)
+            self.br.assign(self.beta_re[i].real)
+            self.bi.assign(self.beta_re[i].imag)
             self.rexi_solver[self.solver_list[i]].solve()
 
             self.w_sum += self.w

--- a/frexi_sphere/rexi_coefficients.py
+++ b/frexi_sphere/rexi_coefficients.py
@@ -120,5 +120,5 @@ def RexiCoefficients(h, M, n=0, reduce_to_half=False):
             beta_re[i] *= 2.0
             beta_im[i] *= 2.0
 
-            print("Done.")
+        print("Done.")
     return alpha, beta_re, beta_im

--- a/frexi_sphere/rexi_coefficients.py
+++ b/frexi_sphere/rexi_coefficients.py
@@ -89,6 +89,7 @@ def b_coefficients(h, M, n=0):
         print("n must be 0, 1 or 2")
 
 def RexiCoefficients(h, M, n=0, reduce_to_half=False):
+    print("Computing Rexi coefficients.")
     params = REXIParameters()
     L = params.L
     mu = params.mu
@@ -119,4 +120,5 @@ def RexiCoefficients(h, M, n=0, reduce_to_half=False):
             beta_re[i] *= 2.0
             beta_im[i] *= 2.0
 
+            print("Done.")
     return alpha, beta_re, beta_im

--- a/tests/test_linear_sw_rexi.py
+++ b/tests/test_linear_sw_rexi.py
@@ -28,7 +28,8 @@ def run(dirname, prob, reduce_to_half):
     im.run(t)
     im_h = im.h_end
     im_u = im.u_end
-    r = LinearExponentialIntegrator(setup, t, True, h, M, reduce_to_half=reduce_to_half)
+    r = LinearExponentialIntegrator(setup, t, direct_solve=False,
+                                    h=h, M=M, reduce_to_half=reduce_to_half)
     r.apply(t, u0, h0, rexi_u, rexi_h)
     h_err = sqrt(assemble((rexi_h - im_h)*(rexi_h - im_h)*dx))/sqrt(assemble(im_h*im_h*dx))
     u_err = sqrt(assemble(inner(rexi_u-im_u, rexi_u-im_u)*dx))/sqrt(assemble(inner(im_u, im_u)*dx))

--- a/tests/test_linear_sw_rexi.py
+++ b/tests/test_linear_sw_rexi.py
@@ -5,7 +5,7 @@ from frexi_sphere.sw_setup import SetupShallowWater
 import pytest
 
 
-def run(dirname, prob, reduce_to_half):
+def run(dirname, prob, reduce_to_half=True):
     family = "BDM"
     degree = 0
     n = 64
@@ -36,9 +36,8 @@ def run(dirname, prob, reduce_to_half):
     return h_err, u_err
 
 @pytest.mark.parametrize("problem", ["wave_scenario", "gaussian_scenario"])
-@pytest.mark.parametrize("reduce_to_half", [True, False])
-def test_linear_sw_rexi(tmpdir, problem, reduce_to_half):
+def test_linear_sw_rexi(tmpdir, problem):
     dirname = str(tmpdir)
-    h_err, u_err = run(dirname, problem, reduce_to_half)
+    h_err, u_err = run(dirname, problem)
     assert h_err < 0.01
     assert u_err < 0.006


### PR DESCRIPTION
This makes a number of preconditioners that are re-used for different REXI solves, allowing bigger problems to be tested in serial.

This is based on a transformation of the equations (basically multiplying the original complex equation by (1+ i*sgn(a_i)) (where a_i is the imaginary part of alpha)) so that a block preconditioner can be used.
There is a different block preconditioner for each value of alpha, and this works best, but we can save memory by using the same block preconditioner for a group of alpha values. This is now controlled by repeat_rate. Setting repeat_rate=1 makes 1 solver per problem, repeat_rate=2 makes 1 solver per 2 problems, etc. The default is 4. The performance of recycling preconditioners is a bit flakey. I found a set up that works for the gauss_scenario now, which is a bit more challenging (I think more modes are present), but let me know if there is a setup where it isn't working that well.

If you can fit the whole problem in memory, always better to use repeat_rate=1 - the solvers will converge in less iterations.